### PR TITLE
Reopenの時にcloseボタンを送信する

### DIFF
--- a/src/forum.js
+++ b/src/forum.js
@@ -40,7 +40,12 @@ export const forumChannelSettings = [
       ].join('\n'),
     onReopen: by =>
       by
-        ? `${userMention(by)}がスレッドを再開しました。`
+        ? [
+            `${userMention(by)}がスレッドを再開しました。`,
+            `${userMention(
+              by
+            )}さんは、間違って再開した場合は下のボタンを押してください。`,
+          ].join('\n')
         : 'スレッドが再開されました。',
     onStale: (ownerId, days) =>
       [

--- a/src/forum.js
+++ b/src/forum.js
@@ -44,7 +44,7 @@ export const forumChannelSettings = [
             `${userMention(by)}がスレッドを再開しました。`,
             `${userMention(
               by
-            )}さんは、間違って再開した場合は下のボタンを押してください。`,
+            )}さんは、意図せず再開した場合は下のボタンを押してください。`,
           ].join('\n')
         : 'スレッドが再開されました。',
     onStale: (ownerId, days) =>


### PR DESCRIPTION
間違えてReopenしてしまう事故が後を絶たないので，Reopenの際のメッセージにクローズボタンを一緒に投げます．

このボタンはReopenするアクションを起こした人だけが押せるようにします．
この人は，そのアクションを起こした時点でDiscordを見ているはずであり，メンションも飛んできますから，間違えてReopenした場合はそうと確実にわかり，ボタンを直ちに押してくれることが期待できます．

テストしていません．