### PR TITLE
Fixed managing unrelated threads

### DIFF
--- a/src/onInterval.js
+++ b/src/onInterval.js
@@ -30,7 +30,12 @@ export async function onInterval(logger, forums) {
  * @param {Forum} param1
  */
 async function onIntervalForForum(logger, { channel, setting }) {
-  const { threads: activeThreads } = await channel.threads.fetchActive()
+  const guildActiveThreads = await channel.guild.channels.fetchActiveThreads(
+    false
+  )
+  const activeThreads = guildActiveThreads.threads.filter(
+    thread => thread.parentId === channel.id
+  )
 
   logger.info(`Found ${activeThreads.size} active threads`)
 


### PR DESCRIPTION
本来処理の対象とすべきではないスレッドまで処理の対象にしてしまっていたので修正する
原因: `channel.threads.fetchActive()`が`Guild`全体のactiveなthreadを返すため