### PR TITLE
add thread lock handler

### DIFF
--- a/src/handleLock.js
+++ b/src/handleLock.js
@@ -1,0 +1,26 @@
+// @ts-check
+import { PermissionFlagsBits } from 'discord.js'
+/**
+ * @typedef {import('./logger.js').Logger} Logger
+ * @typedef {import('discord.js').GuildAuditLogsEntry} GuildAuditLogsEntry
+ * @typedef {import('discord.js').PublicThreadChannel} PublicThreadChannel
+ */
+
+/**
+ * @param {Logger} logger
+ * @param {GuildAuditLogsEntry} entry
+ * @param {PublicThreadChannel} thread ロックされたスレッド
+ */
+export async function handleLock(logger, entry, thread) {
+  if (!entry.executorId) return
+  const executor = await thread.guild.members.fetch(entry.executorId)
+  if (!thread.permissionsFor(executor).has(PermissionFlagsBits.ManageThreads)) {
+    thread.setLocked(
+      false,
+      `${executor.user.tag} (${entry.executorId}) has no ManageThreads permission.`
+    )
+    logger.info(
+      `unlocked "${thread.name}" (${thread.id}) because ${executor.user.tag} (${entry.executorId}) has no ManageThreads permission.`
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import { onInterval } from './onInterval.js'
 import { forumChannelSettings } from './forum.js'
 import { fetchStarterMessageOrNull, lockThreadForNoStarter } from './starter.js'
 import { handleReactionClose } from './handleReactionClose.js'
+import { handleLock } from './handleLock.js'
 /**
  * @typedef {import('discord.js').Channel} Channel
  * @typedef {import('discord.js').ForumChannel} ForumChannel
@@ -81,6 +82,14 @@ client.on(Events.GuildAuditLogEntryCreate, async (auditLogEntry, guild) => {
       auditLogEntry,
       newThread,
       setting
+    )
+  if (
+    auditLogEntry.changes.some(it => it.key === 'locked' && !it.old && it.new)
+  )
+    await handleLock(
+      logger.createChild('onForumThreadLock'),
+      auditLogEntry,
+      newThread
     )
 })
 


### PR DESCRIPTION
iOS・iPadOS版およびAndroid版Discordでは、権限がなくてもスレ主ならばロックできるため、その対策。